### PR TITLE
Änderungen an Covid-19 Sektion, allgemeinen Texten, HTML

### DIFF
--- a/apps/templates/pages/about.html
+++ b/apps/templates/pages/about.html
@@ -43,7 +43,7 @@
                             Quidditch Austria
                         </a>
  
-                        <a class="navbar-item is-slide" href="/covid19/">
+                        <a class="navbar-item is-slide" href="#covid19">
                             COVID-19 Update
                         </a>
  			<a class="navbar-item is-slide" href="{% url "about" %}">

--- a/apps/templates/pages/home.html
+++ b/apps/templates/pages/home.html
@@ -205,7 +205,7 @@
                                             <i class="im im-icon-Notepad"></i>
                                         </div>
                                         <div class="box-title">Spielbetrieb</div>
-                                        <p class="box-content">Quidditch Austria kümmert sich von den Grundlagen, wie die Herausgabe eines aktuellen Regelwerks, die Entwicklung von Schiedsrichtern bis hin zur Austragung.</p>
+                                        <p class="box-content">Quidditch Austria kümmert sich um die Grundlagen, wie die Herausgabe eines aktuellen Regelwerks, die Entwicklung von Schiedsrichtern bis hin zur Austragung von Turnieren.</p>
                                     </div>
                                 </div>
                                 <!-- Icon block -->
@@ -215,7 +215,7 @@
                                             <i class="im im-icon-Trophy"></i>
                                         </div>
                                         <div class="box-title">Sportveranstalter</div>
-                                        <p class="box-content">Wir fungieren koordinierende Stelle der Central European Quidditch League sowie Veranstalter von Turnieren wie dem Austrian Quidditch Cup und dem Danube Cup.</p>
+                                        <p class="box-content">Wir fungieren als koordinierende Stelle der Central European Quidditch League sowie als Veranstalter von Turnieren wie dem Austrian Quidditch Cup und dem Danube Cup.</p>
                                     </div>
                                 </div>
                                 <!-- Icon block -->

--- a/apps/templates/pages/home.html
+++ b/apps/templates/pages/home.html
@@ -89,7 +89,7 @@
                     <div class="Wallop-caption-wrapper">
                         <div class="Wallop-caption is-centered">
                             <div class="main-inner">
-                                <h1>Do m&ouml;chtest Quidditch kennenlernen?</h1>
+                                <h1>Du m&ouml;chtest Quidditch kennenlernen?</h1>
                             </div>
                             <div>
                                 <h4>Mit Mannschaften &uuml;ber ganz &Ouml;sterreich verteilt findest du Quidditch auch in deiner N&auml;he!</h4>

--- a/apps/templates/pages/home.html
+++ b/apps/templates/pages/home.html
@@ -75,7 +75,7 @@
                                 <h1>Wir sind Quidditch Austria</h1>
                             </div>
                             <div>
-                                <h4>Als Dachverband des &ouml;sterreichischen Quidditch Sports, bringen wir Quidditch weiter!</h4>
+                                <h4>Als Fachverband des &ouml;sterreichischen Quidditch Sports, bringen wir Quidditch weiter!</h4>
                             </div>
                             <div class="caption-action">
                                 <a href="#services" class="button button-cta btn-align light-btn btn-outlined is-bold rounded">Unsere Services</a>

--- a/apps/templates/pages/home.html
+++ b/apps/templates/pages/home.html
@@ -41,7 +41,7 @@
                         <a class="navbar-item is-slide" href="/">
                             Quidditch Austria
                         </a>
-                        <a class="navbar-item is-slide" href="covid19">
+                        <a class="navbar-item is-slide" href="#covid19">
                             COVID-19 Update
                         </a>
                         <a class="navbar-item is-slide" href="{% url "about" %}">

--- a/apps/templates/pages/home.html
+++ b/apps/templates/pages/home.html
@@ -41,7 +41,7 @@
                         <a class="navbar-item is-slide" href="/">
                             Quidditch Austria
                         </a>
-                        <a class="navbar-item is-slide" href="/covid19/">
+                        <a class="navbar-item is-slide" href="covid19">
                             COVID-19 Update
                         </a>
                         <a class="navbar-item is-slide" href="{% url "about" %}">
@@ -137,7 +137,7 @@
         <section id="services" class="section is-medium section-feature-grey">
             <div class="container">
                 <div class="centered-title">
-                    <h2>Empfehlungen zur COVID-19 Pr&auml;vention</h2>
+                    <h2 id="covid19">Empfehlungen zur COVID-19 Pr&auml;vention</h2>
                     <div class="title-divider"></div>
                     <div class="subheading">
                         Stand 2. Juni 2020

--- a/apps/templates/pages/home.html
+++ b/apps/templates/pages/home.html
@@ -75,7 +75,7 @@
                                 <h1>Wir sind Quidditch Austria</h1>
                             </div>
                             <div>
-                                <h4>Als Dachverband des österreichischen Quidditch Sports, bringen wir Quidditch weiter!</h4>
+                                <h4>Als Dachverband des &ouml;sterreichischen Quidditch Sports, bringen wir Quidditch weiter!</h4>
                             </div>
                             <div class="caption-action">
                                 <a href="#services" class="button button-cta btn-align light-btn btn-outlined is-bold rounded">Unsere Services</a>
@@ -89,10 +89,10 @@
                     <div class="Wallop-caption-wrapper">
                         <div class="Wallop-caption is-centered">
                             <div class="main-inner">
-                                <h1>Do möchtest Quidditch kennenlernen?</h1>
+                                <h1>Do m&ouml;chtest Quidditch kennenlernen?</h1>
                             </div>
                             <div>
-                                <h4>Mit Mannschaften über ganz Österreich verteilt findest du Quidditch auch in deiner Nähe!</h4>
+                                <h4>Mit Mannschaften &uuml;ber ganz &Ouml;sterreich verteilt findest du Quidditch auch in deiner N&auml;he!</h4>
                             </div>
                             <div class="caption-action">
                                 <a href="#teams" class="button button-cta btn-align light-btn btn-outlined is-bold rounded">Teams</a>
@@ -106,13 +106,13 @@
                     <div class="Wallop-caption-wrapper">
                         <div class="Wallop-caption is-centered">
                             <div class="main-inner">
-                                <h1>Selbst ein Team gründen?</h1>
+                                <h1>Selbst ein Team gr&uuml;nden?</h1>
                             </div>
                             <div>
-                                <h4>Quidditch Austria hilft dir bei der Gründung deines eigenen Quidditch Teams!</h4>
+                                <h4>Quidditch Austria hilft dir bei der Gr&uuml;ndung deines eigenen Quidditch Teams!</h4>
                             </div>
                             <div class="caption-action">
-                                <a href="#starting" class="button button-cta btn-align light-btn btn-outlined is-bold rounded">Zur Teamgründung</a>
+                                <a href="#starting" class="button button-cta btn-align light-btn btn-outlined is-bold rounded">Zur Teamgr&uuml;ndung</a>
                             </div>
                         </div>
                     </div>
@@ -153,7 +153,7 @@
                                 <div class="title-divider"></div>
                                 <p>Quidditch Austria hat in Abstimmung mit der Bundessport-Organisation folgende Empfehlungen f&uuml;r die Durchf&uuml;hrung von Gruppentrainings in Hallen und im Freien erarbeitet</p>
                                 <div class="action">
-                                    <a class="button btn-align button-cta btn-outlined raised rounded primary-btn is-bold" href="https://quidditch.at/static/files/qat_covid_praevention.pdf">QAT Empfehlungen zur COVID-19 Prävention</a>
+                                    <a class="button btn-align button-cta btn-outlined raised rounded primary-btn is-bold" href="https://quidditch.at/static/files/qat_covid_praevention.pdf">QAT Empfehlungen zur COVID-19 Pr&auml;vention</a>
                                 </div>
                             </div>
                         </div>
@@ -168,7 +168,7 @@
                     <h2>Lern uns kennen</h2>
                     <div class="title-divider"></div>
                     <div class="subheading">
-                        Was macht Quidditch Austria überhaupt?
+                        Was macht Quidditch Austria &uuml;berhaupt?
                     </div>
                 </div>
 
@@ -179,9 +179,9 @@
                             <div class="service-box">
                                 <h2 class="service-title">Vereinszweck</h2>
                                 <div class="title-divider"></div>
-                                <p>Der Verein, dessen Tätigkeit nicht auf Gewinn gerichtet ist, bezweckt die Förderung der körperlichen und geistigen Leistungsfähigkeit seiner Mitglieder durch Pflege des Sports Quidditch, sowie die Verbreitung und Förderung des Sports in Österreich. Weiters bekennt sich der Verein zum Gedanken der Völkerverständigung, sowie der Förderung einer Gemeinschaft der Toleranz und des Respekts.</p>
+                                <p>Der Verein, dessen T&auml;tigkeit nicht auf Gewinn gerichtet ist, bezweckt die F&ouml;rderung der k&ouml;rperlichen und geistigen Leistungsf&auml;higkeit seiner Mitglieder durch Pflege des Sports Quidditch, sowie die Verbreitung und F&ouml;rderung des Sports in &Ouml;sterreich. Weiters bekennt sich der Verein zum Gedanken der V&ouml;lkerverst&auml;ndigung, sowie der F&ouml;rderung einer Gemeinschaft der Toleranz und des Respekts.</p>
                                 <div class="action">
-                                    <a class="button btn-align button-cta btn-outlined raised rounded primary-btn is-bold">Mehr über uns</a>
+                                    <a class="button btn-align button-cta btn-outlined raised rounded primary-btn is-bold">Mehr &uuml;ber uns</a>
                                 </div>
                             </div>
                         </div>
@@ -195,7 +195,7 @@
                                             <i class="im im-icon-Megaphone"></i>
                                         </div>
                                         <div class="box-title">Sport Entwicklung</div>
-                                        <p class="box-content">Wir haben uns zum Ziel gesetzt Quidditch in Österreich als bekannte Randsportart zu etablieren und allen den Einstieg in die Sportart zu ermöglichen</p>
+                                        <p class="box-content">Wir haben uns zum Ziel gesetzt Quidditch in &Ouml;sterreich als bekannte Randsportart zu etablieren und allen den Einstieg in die Sportart zu erm&ouml;glichen</p>
                                     </div>
                                 </div>
                                 <!-- Icon block -->
@@ -205,7 +205,7 @@
                                             <i class="im im-icon-Notepad"></i>
                                         </div>
                                         <div class="box-title">Spielbetrieb</div>
-                                        <p class="box-content">Quidditch Austria kümmert sich um die Grundlagen, wie die Herausgabe eines aktuellen Regelwerks, die Entwicklung von Schiedsrichtern bis hin zur Austragung von Turnieren.</p>
+                                        <p class="box-content">Quidditch Austria k&uuml;mmert sich um die Grundlagen, wie die Herausgabe eines aktuellen Regelwerks, die Entwicklung von Schiedsrichtern bis hin zur Austragung von Turnieren.</p>
                                     </div>
                                 </div>
                                 <!-- Icon block -->
@@ -225,7 +225,7 @@
                                             <i class="im im-icon-Globe"></i>
                                         </div>
                                         <div class="box-title">Nationale und Internationale Vernetzung</div>
-                                        <p class="box-content">Wir repräsentieren die Interessen des österreichischen Quidditch Sports innerhalb Österreichs, in Kooperation mit Nachbarländern und in internationalen Gremien.</p>
+                                        <p class="box-content">Wir repr&auml;sentieren die Interessen des &ouml;sterreichischen Quidditch Sports innerhalb &Ouml;sterreichs, in Kooperation mit Nachbarl&auml;ndern und in internationalen Gremien.</p>
                                     </div>
                                 </div>
                             </div>
@@ -241,10 +241,10 @@
         <section id="teams" class="section is-medium">
             <div class="container">
                 <div class="centered-title">
-                    <h2>Teams in Österreich</h2>
+                    <h2>Teams in &Ouml;sterreich</h2>
                     <div class="title-divider"></div>
                     <div class="subheading">
-                        Finde ein Team in deiner Nähe!
+                        Finde ein Team in deiner N&auml;he!
                     </div>
                 </div>
 
@@ -358,10 +358,10 @@
         <section id="starting" class="section section-feature-grey is-medium">
             <div class="container">
                 <div class="centered-title">
-                    <h2>Gründe ein Team</h2>
+                    <h2>Gr&uuml;nde ein Team</h2>
                     <div class="title-divider"></div>
                     <div class="subheading">
-                        Wir unterstützen dich bei der Gründung eines neuen Quidditch Teams!
+                        Wir unterst&uuml;tzen dich bei der Gr&uuml;ndung eines neuen Quidditch Teams!
                     </div>
                 </div>
 
@@ -405,7 +405,7 @@
                                     <h4>Hilfestellung</h4>
                                 </div>
                                 <div class="card-feature-description">
-                                    <span class="">Wir begleiten euer Team von der Gründung bis zu den Meisterschaften.</span>
+                                    <span class="">Wir begleiten euer Team von der Gr&uuml;ndung bis zu den Meisterschaften.</span>
                                 </div>
                             </div>
                         </div>
@@ -414,7 +414,7 @@
 
                 <!-- CTA -->
                 <div class="centered-title pt-40">
-                    <a href="/about/" class="button button-cta is-bold btn-align primary-btn btn-outlined rounded is-title-reveal">Ich möchte ein Team gründen</a>
+                    <a href="/about/" class="button button-cta is-bold btn-align primary-btn btn-outlined rounded is-title-reveal">Ich m&ouml;chte ein Team gr&uuml;nden</a>
                 </div>
                 <!-- /CTA -->
             </div>

--- a/apps/templates/pages/home.html
+++ b/apps/templates/pages/home.html
@@ -149,7 +149,7 @@
                         <!-- Content -->
                         <div class="column is-8">
                             <div class="service-box">
-                                <h2 class="service-title">Kleingruppentraining im Freien erlaubt</h2>
+                                <h2 class="service-title">Gruppentraining erlaubt</h2>
                                 <div class="title-divider"></div>
                                 <p>Quidditch Austria hat in Abstimmung mit der Bundessport-Organisation folgende Empfehlungen f&uuml;r die Durchf&uuml;hrung von Gruppentrainings in Hallen und im Freien erarbeitet</p>
                                 <div class="action">


### PR DESCRIPTION
- Covid-19 Deeplink als Link zur Covid-19 Sektion im Hauptmenu abgeändert
- Den Covid Titel verkürzt
- Umlaute durch ihren HTML Code ersetzt
- Die Allgemeinen Texte angepasst